### PR TITLE
updating nuage-openstack-upgrade tarball name

### DIFF
--- a/queens/project-neutron/nuage-neutron-server-dockerfile
+++ b/queens/project-neutron/nuage-neutron-server-dockerfile
@@ -21,8 +21,8 @@ COPY licenses /licenses
 
 RUN mkdir -p /opt/nuage_upgrade
 WORKDIR /opt/nuage_upgrade
-ADD https://s3-us-west-1.amazonaws.com/nuage-public-mirror/574d63bb0727c27e014d8f27ccc275c3f9641b955e8aa7659d74e4df9cf7847a/6.0.2/queens/nuage-openstack-upgrade-6.0.2-15.tar.gz .
-RUN tar -xzf nuage-openstack-upgrade-6.0.2-15.tar.gz
+ADD https://s3-us-west-1.amazonaws.com/nuage-public-mirror/574d63bb0727c27e014d8f27ccc275c3f9641b955e8aa7659d74e4df9cf7847a/6.0.2/queens/nuage-openstack-upgrade-6.0.2-19.tar.gz .
+RUN tar -xzf nuage-openstack-upgrade-6.0.2-19.tar.gz
 WORKDIR /
 
 USER neutron


### PR DESCRIPTION
nuage-openstack-upgrade tarball name is updated from nuage-openstack-upgrade-6.0.2-15.tar.gz to nuage-openstack-upgrade-6.0.2-19.tar.gz
